### PR TITLE
Fix for Minecraft Versions older than 1.20.80

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Entering the [installation command](#installation) will invoke the [installer sc
 
 Though an initial backup is performed upon first starting the installer, you may also use the _Backup_ option to export the current preset as a `.mcpack` file. These settings can later be restored by installing the backup file as a custom preset.
 
-##### Uninistall
+##### Uninstall
 
 Selecting the _Uninstall_ option will revert the BetterRTX Installer's changes and remove its cached files.
 

--- a/v1/BetterRTX_Installer.ps1
+++ b/v1/BetterRTX_Installer.ps1
@@ -318,9 +318,9 @@ Switch ($selection) {
             } else {
                 Invoke-WebRequest -URI $newToneMappingUrl -OutFile $newTonemapping -UseBasicParsing;
             }
-        } else if ($majorVer -lt 20) {
+        } elseif ($majorVer -lt 20) {
             Invoke-WebRequest -URI $oldToneMappingUrl -OutFile $newTonemapping -UseBasicParsing;
-        } else if ($majorVer -gt 20) {
+        } elseif ($majorVer -gt 20) {
             Invoke-WebRequest -URI $newToneMappingUrl -OutFile $newTonemapping -UseBasicParsing;
         } else {
             # Something went wrong. Fallback to newToneMappingUrl


### PR DESCRIPTION
This attempts to fix the BetterRTX Server installer for Minecraft Versions older than 1.20.80 by using an older tonemapping binary file.

There's also a slight dictation fix to the README.md file.

**TODO**: Use bedrock.graphics's CDN instead of relying on Discord's CDN.

**WARNING: THE FOLLOWING CODE IS UNTESTED!**