### PR TITLE
feat: .rtpack file registration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+- Prefer `[void]` over `| OutNull` to suppress GUI output in the host console.
+- Always wrap error-prone code in try/catch.
+- Do not use if/else when it is possible to use if/return instead.
+- Use camel case in variable names.
+- Always use `$T.` when adding text labels. Add the translation to `$T`

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "github.copilot.chat.codeGeneration.useInstructionFiles": true
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Better RTX Installer
 
-https://github.com/user-attachments/assets/eb3ce4a4-600c-4999-bee3-3e43abc00479
-
 ### Prerequisites
 
 - Use software like
@@ -10,23 +8,23 @@ https://github.com/user-attachments/assets/eb3ce4a4-600c-4999-bee3-3e43abc00479
   easily create a side-loaded Minecraft installation.
 - **OR** download [IOBit Unlocker](https://www.iobit.com/en/iobit-unlocker.php)
   to allow copying to Minecraft Launcher/Windows Store installations.
-- **OR** use
-  [BetterRenderDragon](https://github.com/ddf8196/BetterRenderDragon/releases)
-  with a [BetterRTX `.mcpack` release](https://bedrock.graphics/release/latest). (BetterRTX Installer not required.)
 
-## Installation
+## Launch Installer GUI
 Copy and paste the following line into a command terminal to start the installer. _(English version)_
 
 ```
 powershell -c "iwr https://bedrock.graphics/installer -useb | iex"
 ```
 
----
+## Translations
 
-#### Translations
-[Download the latest release](https://github.com/BetterRTX/BetterRTX-Installer/releases) to launch the installer interface in your preferred language. ([View supported languages.](https://github.com/BetterRTX/BetterRTX-Installer/tree/prerelease/v2/Localized))
+With help from several [contributors](https://github.com/BetterRTX/BetterRTX-Installer/graphs/contributors), the installer interface has been translated into [multiple languages](https://github.com/BetterRTX/BetterRTX-Installer/tree/prerelease/v2/Localized).
 
-Right click the `installer.ps1` file and select _Run with PowerShell_ to start the installer script.
+Enter this command in a __64-bit PowerShell__ terminal to launch the installer in your preferred language (if available).
+
+```powershell
+iwr https://bedrock.graphics/installer/v2/$PsUICulture | iex
+```
 
 ---
 
@@ -41,12 +39,6 @@ or
 for additional help.
 
 [Read the Wiki](https://github.com/BetterRTX/BetterRTX-Installer/wiki) for more details and instructions.
-
-
-## Screenshots
-
-![BetterRTX](https://github.com/BetterRTX/BetterRTX-Installer/assets/81783950/ef6a098d-3f54-48cf-ad83-1a709d251fd1)
-> ###### Screenshot courtesy @jancaplayer on Discord
 
 ---
 

--- a/v2/Localized/en-US/installer.psd1
+++ b/v2/Localized/en-US/installer.psd1
@@ -25,4 +25,5 @@ ConvertFrom-StringData -StringData @'
     backup = Backup
     restore = Restore
     create_initial_backup = Creating initial backup...
+    register_rtpack = Register .rtpack extension
 '@

--- a/v2/installer.ps1
+++ b/v2/installer.ps1
@@ -174,8 +174,14 @@ function Add-RunWithArguments {
 
         $dir = Expand-Pack -Pack $FilePath
 
-        Write-Host "🚀 Ready to install!" -ForegroundColor Green
+        Write-Host "Ready to install!" -ForegroundColor Green
         foreach ($mc in $dataSrc) {
+            $continue = Read-Host "Install $FilePath to $($mc.FriendlyName)? (Y/N)"
+
+            if ($continue -notlike "Y*") {
+                continue
+            }
+
             $success = $false;
 
             # Delete old files

--- a/v2/installer.ps1
+++ b/v2/installer.ps1
@@ -1,4 +1,3 @@
-#!/usr/bin/env pwsh
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 
@@ -31,6 +30,7 @@ $T = Data {
     backup = Backup
     backup_instance_location = Select backup location for instance
     create_initial_backup = Creating initial backup
+    register_rtpack = Register .rtpack extension
 '@
 }
 $translationFilename = "installer.psd1"
@@ -56,7 +56,7 @@ if (-not (Test-Path $localizedDataPath)) {
             $localLocaleDir = Join-Path -Path $PSScriptRoot -ChildPath "Localized"
 
             if (Test-Path $localLocaleDir) {
-                Clear-Host
+                # Clear-Host
                 $localeDir = $localLocaleDir
                 Write-Debug "Using translations in `"$localeDir`""
             }
@@ -65,13 +65,31 @@ if (-not (Test-Path $localizedDataPath)) {
 }
 
 Import-LocalizedData -BaseDirectory $localeDir -ErrorAction:SilentlyContinue -BindingVariable T -FileName $translationFilename
-Clear-Host
+# Clear-Host
 
-$hasSideloaded = (Get-AppxPackage -Name "Microsoft.Minecraft*" | Where-Object { $_.InstallLocation -notlike "C:\Program Files\WindowsApps\*" }).Count -gt 0
+Write-Host "🚩 Using translations data in `"$localeDir`"" -ForegroundColor Magenta
+
+$hasSideloaded = @(Get-AppxPackage -Name "Microsoft.Minecraft*" | Where-Object { 
+        $_.InstallLocation -notlike "C:\Program Files\WindowsApps\*" -and 
+        $_.InstallLocation -notlike "*Java*"
+    }).Count -gt 0
+
+if ($hasSideloaded) {
+    Write-Host "🎮 Sideloaded Minecraft installations detected" -ForegroundColor Green
+}
+
 $ioBit = Get-StartApps | Where-Object { $_.Name -eq "IObit Unlocker" }
+
+if ($ioBit) {
+    Write-Host "🔓 IObit Unlocker available" -ForegroundColor Cyan
+}
 
 # Whether to copy all materials at once or in a loop
 $doSinglePass = $args -contains "-singlePass"
+
+if ($doSinglePass -and $ioBit) {
+    Write-Host "🏎️ Copying all materials in one pass!" -ForegroundColor Yellow
+}
 
 $dataSrc = @()
 
@@ -87,6 +105,116 @@ foreach ($mc in (Get-AppxPackage -Name "Microsoft.Minecraft*")) {
     }
 }
 
+function Register-RtpackExtension {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$InstallerPath
+    )
+
+    $rtpackKey = "Registry::HKEY_CURRENT_USER\Software\Classes\.rtpack"
+
+    if (Test-Path $rtpackKey) {
+        Remove-Item -Path $rtpackKey -Force
+    }
+    
+    try {
+        $rtpackAppKey = "Registry::HKEY_CURRENT_USER\Software\Classes\BetterRTX.PackageFile"
+        
+        New-Item -Path $rtpackKey -Force | Out-Null
+        Set-ItemProperty -Path $rtpackKey -Name "(Default)" -Value "BetterRTX.PackageFile"
+        
+        New-Item -Path $rtpackAppKey -Force | Out-Null
+        Set-ItemProperty -Path $rtpackAppKey -Name "(Default)" -Value "BetterRTX Preset"
+        
+        $batPath = "$BRTX_DIR\install_rtpack.bat"
+        $batContent = "@echo off`n`powershell -f `"$InstallerPath`" `"%1`""
+        $batContent | Out-File $batPath -Encoding ASCII
+
+        New-Item -Path "$rtpackAppKey\shell\open\command" -Force | Out-Null
+        Set-ItemProperty -Path "$rtpackAppKey\shell\open\command" -Name "(Default)" -Value "$batPath `"%1`""
+        
+        $iconPath = "$BRTX_DIR\rtpack.ico"
+        if (-not (Test-Path $iconPath)) {
+            # Download the favicon from https://bedrock.graphics
+            $iconUrl = "https://bedrock.graphics/favicon.ico"
+            $iconContent = Invoke-WebRequest -Uri $iconUrl -ContentType "image/x-icon" -UseBasicParsing
+            $iconContent | Out-File "$BRTX_DIR\rtpack.ico"
+        }
+        
+        Set-ItemProperty -Path $rtpackAppKey -Name "DefaultIcon" -Value "$iconPath,0"
+        
+        if (-not [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+            Write-Warning "Shell refresh only supported on Windows"
+            return
+        }
+        $signature = @'
+        [DllImport("shell32.dll")]
+        public static extern void SHChangeNotify(int eventId, int flags, IntPtr item1, IntPtr item2);
+'@
+        Add-Type -MemberDefinition $signature -Namespace Shell32 -Name Utils
+        [Shell32.Utils]::SHChangeNotify(0x08000000, 0, [IntPtr]::Zero, [IntPtr]::Zero)
+
+        $registered = Test-Path $rtpackKey
+
+        if (-not $registered) {
+            throw "Failed to register .rtpack extension"
+        }
+        
+        Write-Host "Successfully registered .rtpack extension" -ForegroundColor Green
+    }
+    catch {
+        Write-Error "Failed to register .rtpack extension: $_"
+    }
+}
+
+function Add-RunWithArguments {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath
+    )
+    
+    if ($FilePath -and (Test-Path $FilePath)) {
+
+        $dir = Expand-Pack -Pack $FilePath
+
+        Write-Host "🚀 Ready to install!" -ForegroundColor Green
+        foreach ($mc in $dataSrc) {
+            $success = $false;
+
+            # Delete old files
+            if ($ioBit) {
+                Write-Host "Deleting existing files in `"$($mc.FriendlyName)`"..."
+                $success = IoBitDelete -Materials @("RTXStub.material.bin", "RTXPostFX.Tonemapping.material.bin") -Location "$($mc.InstallLocation)\data\renderer\materials"
+                if (-not $success) {
+                    Write-Host "Failed to delete existing files"
+                    return
+                }
+
+                Write-Host "Deleted existing files"
+                Start-Sleep -Milliseconds 100
+
+                Write-Host "Copying to `"$($mc.FriendlyName)`"..."
+                $success = IoBitCopy -Materials @("$dir\RTXStub.material.bin", "$dir\RTXPostFX.Tonemapping.material.bin") -Destination $mc.InstallLocation -singlePass $true
+            }
+            else {
+                Write-Host "Copying from `"$dir`" to `"$($mc.FriendlyName)`"..."
+                $success = Copy-ShaderFiles -Location $mc.InstallLocation -Materials @("$dir\RTXStub.material.bin", "$dir\RTXPostFX.Tonemapping.material.bin")
+            }
+
+            if (-not $success) {
+                Write-Host "Failed to copy new files"
+                return
+            }
+
+            Write-Host "Copied new files"
+        }
+
+        return $true
+    }
+
+}
+
+
 # Based on https://gist.github.com/ABUCKY0/31b0b5b8691858930fccffa06da39b46
 function IoBitGetExe() {
     if ($null -eq $ioBit) {
@@ -96,11 +224,9 @@ function IoBitGetExe() {
     $guid = ($ioBit.AppID -split "\\")[0].TrimStart("{").TrimEnd("}")
 
     $KnownFolders = @{
-        '3DObjects'             = '31C0DD25-9439-4F12-BF41-7FF4EDA38722';
         'AddNewPrograms'        = 'de61d971-5ebc-4f02-a3a9-6c82895e5c04';
         'AdminTools'            = '724EF170-A42D-4FEF-9F26-B60E846FBA4F';
         'AppUpdates'            = 'a305ce99-f527-492b-8b1a-7e76fa98d6e4';
-        'CDBurning'             = '9E52AB10-F80D-49DF-ACB8-4330F5687855';
         'ChangeRemovePrograms'  = 'df7266ac-9274-4867-8d55-3bd661de872d';
         'CommonAdminTools'      = 'D0384E7D-BAC3-4797-8F14-CBA229B392B5';
         'CommonOEMLinks'        = 'C1BAE2D0-10DF-4334-BEDD-7AA20B227A9D';
@@ -110,15 +236,11 @@ function IoBitGetExe() {
         'CommonTemplates'       = 'B94237E7-57AC-4347-9151-B08C6C32D1F7';
         'ComputerFolder'        = '0AC0837C-BBF8-452A-850D-79D08E667CA7';
         'ConflictFolder'        = '4bfefb45-347d-4006-a5be-ac0cb0567192';
-        'ConnectionsFolder'     = '6F0CD92B-2E97-45D1-88FF-B0D186B8DEDD';
-        'Contacts'              = '56784854-C6CB-462b-8169-88E350ACB882';
         'ControlPanelFolder'    = '82A74AEB-AEB4-465C-A014-D097EE346D63';
-        'Cookies'               = '2B0F765D-C0E9-4171-908E-08A611B84FF6';
         'Desktop'               = 'B4BFCC3A-DB2C-424C-B029-7FE99A87C641';
         'Documents'             = 'FDD39AD0-238F-46AF-ADB4-6C85480369C7';
         'Downloads'             = '374DE290-123F-4565-9164-39C4925E467B';
         'Favorites'             = '1777F761-68AD-4D8A-87BD-30B759FA33DD';
-        'Fonts'                 = 'FD228CB7-AE11-4AE3-864C-16F3910AB8FE';
         'Games'                 = 'CAC52C1A-B53D-4edc-92D7-6B2E8AC19434';
         'GameTasks'             = '054FAE61-4DD8-4787-80B6-090220C4B700';
         'History'               = 'D9DC8A3B-B784-432E-A781-5A1130A75963';
@@ -128,15 +250,6 @@ function IoBitGetExe() {
         'LocalAppData'          = 'F1B32785-6FBA-4FCF-9D55-7B8E7F157091';
         'LocalAppDataLow'       = 'A520A1A4-1780-4FF6-BD18-167343C5AF16';
         'LocalizedResourcesDir' = '2A00375E-224C-49DE-B8D1-440DF7EF3DDC';
-        'Music'                 = '4BD8D571-6D19-48D3-BE97-422220080E43';
-        'NetHood'               = 'C5ABBF53-E17F-4121-8900-86626FC2C973';
-        'NetworkFolder'         = 'D20BEEC4-5CA8-4905-AE3B-BF251EA09B53';
-        'OriginalImages'        = '2C36C0AA-5812-4b87-BFD0-4CD0DFB19B39';
-        'PhotoAlbums'           = '69D2CF90-FC33-4FB7-9A0C-EBB0F0FCB43C';
-        'Pictures'              = '33E28130-4E1E-4676-835A-98395C3BC3BB';
-        'Playlists'             = 'DE92C1C7-837F-4F69-A3BB-86E631204A23';
-        'PrintersFolder'        = '76FC4E2D-D6AD-4519-A663-37BD56068185';
-        'PrintHood'             = '9274BD8D-CFD1-41C3-B35E-B13F55A758F4';
         'Profile'               = '5E6C858F-0E22-4760-9AFE-EA3317B67173';
         'ProgramData'           = '62AB5D82-FDC1-4DC3-A9DD-070D1D495D97';
         'ProgramFiles'          = '905e63b6-c1bf-494e-b29c-65b732d3d21a';
@@ -151,25 +264,13 @@ function IoBitGetExe() {
         'PublicDocuments'       = 'ED4824AF-DCE4-45A8-81E2-FC7965083634';
         'PublicDownloads'       = '3D644C9B-1FB8-4f30-9B45-F670235F79C0';
         'PublicGameTasks'       = 'DEBF2536-E1A8-4c59-B6A2-414586476AEA';
-        'PublicMusic'           = '3214FAB5-9757-4298-BB61-92A9DEAA44FF';
-        'PublicPictures'        = 'B6EBFB86-6907-413C-9AF7-4FC2ABF07CC5';
-        'PublicVideos'          = '2400183A-6185-49FB-A2D8-4A392A602BA3';
         'QuickLaunch'           = '52a4f021-7b75-48a9-9f6b-4b87a210bc8f';
         'Recent'                = 'AE50C081-EBD2-438A-8655-8A092E34987A';
-        'RecycleBinFolder'      = 'B7534046-3ECB-4C18-BE4E-64CD4CB7D6AC';
         'ResourceDir'           = '8AD10C31-2ADB-4296-A8F7-E4701232C972';
         'RoamingAppData'        = '3EB685DB-65F9-4CF6-A03A-E3EF65729F3D';
-        'SampleMusic'           = 'B250C668-F57D-4EE1-A63C-290EE7D1AA1F';
-        'SamplePictures'        = 'C4900540-2379-4C75-844B-64E6FAF8716B';
-        'SamplePlaylists'       = '15CA69B3-30EE-49C1-ACE1-6B5EC372AFB5';
-        'SampleVideos'          = '859EAD94-2E85-48AD-A71A-0969CB56A6CD';
         'SavedGames'            = '4C5C32FF-BB9D-43b0-B5B4-2D72E54EAAA4';
-        'SavedSearches'         = '7d1d3a04-debb-4115-95cf-2f29da2920da';
         'SEARCH_CSC'            = 'ee32e446-31ca-4aba-814f-a5ebd2fd6d5e';
         'SEARCH_MAPI'           = '98ec0e18-2098-4d44-8644-66979315a281';
-        'SearchHome'            = '190337d1-b8ca-4121-a639-6d472d16972a';
-        'SendTo'                = '8983036C-27C0-404B-8F08-102D10DCFD74';
-        'SidebarDefaultParts'   = '7B396E54-9EC5-4300-BE0A-2482EBAE1A26';
         'SidebarParts'          = 'A75D362E-50FC-4fb7-AC2C-A8BEAA314493';
         'StartMenu'             = '625B53C3-AB48-4EC1-BA1F-A1EF4146FC19';
         'Startup'               = 'B97D20BB-F46A-4C97-BA10-5E3608430854';
@@ -178,11 +279,9 @@ function IoBitGetExe() {
         'SyncSetupFolder'       = '0F214138-B1D3-4a90-BBA9-27CBC0C5389A';
         'System'                = '1AC14E77-02E7-4E5D-B744-2EB1AE5198B7';
         'SystemX86'             = 'D65231B0-B2F1-4857-A4CE-A8E7C6EA7D27';
-        'Templates'             = 'A63293E8-664E-48DB-A079-DF759E0509F7';
         'TreeProperties'        = '5b3749ad-b49f-49c1-83eb-15370fbd4882';
         'UserProfiles'          = '0762D272-C50A-4BB0-A382-697DCD729B80';
         'UsersFiles'            = 'f3ce0f7c-4901-4acc-8648-d5d44b04ef8f';
-        'Videos'                = '18989B1D-99B5-455B-841C-AB7C74E4DDFC';
         'Windows'               = 'F38BF404-1D43-42F2-9305-67DE0B28FC23';
     }
 
@@ -220,19 +319,29 @@ function Backup-InitialShaderFiles() {
         [string]$BackupDir = "$BRTX_DIR\backup"
     )
 
-    $mcSrc = "$Location\data\renderer\materials"
-
-    if (-not (Test-Path $BackupDir)) {
-        New-Item -ItemType Directory -Path $BackupDir -Force | Out-Null
-    }
-
-    foreach ($file in $Materials) {
-        $src = "$mcSrc\$file"
-        $dest = "$BackupDir\$file"
-
-        if (Test-Path $src) {
-            Copy-Item -Path $src -Destination $dest -Force -ErrorAction Stop
+    try {
+        $mcSrc = "$Location\data\renderer\materials"
+        
+        if (-not (Test-Path $BackupDir)) {
+            New-Item -ItemType Directory -Path $BackupDir -Force -ErrorAction Stop | Out-Null
         }
+
+        foreach ($file in $Materials) {
+            $src = "$mcSrc\$file"
+            $dest = "$BackupDir\$file"
+
+            if (Test-Path $src) {
+                Copy-Item -Path $src -Destination $dest -Force -ErrorAction Stop
+            }
+            else {
+                Write-Warning "Source file not found: $src"
+            }
+        }
+        return $true
+    }
+    catch {
+        Write-Error "Failed to backup shader files: $_"
+        return $false
     }
 }
 
@@ -289,53 +398,47 @@ function Copy-ShaderFiles() {
         [string[]]$Materials
     )
 
-    $mcDest = "$Location\data\renderer\materials"
+    try {
+        $mcDest = "$Location\data\renderer\materials"
 
-    $isSideloaded = $Location -notlike "C:\Program Files\WindowsApps\*"
-    
-    $StatusLabel.Visible = $false
-
-    if ($isSideloaded) {
-        $StatusLabel.Text = $T.copying
-        $StatusLabel.ForeColor = 'Blue'
-        $StatusLabel.Visible = $true
-        Copy-Item -Path $Materials -Destination $mcDest -Force -ErrorAction Stop
-        return $true
-    }
-
-    if ($ioBit) {
-        $StatusLabel.Text = $T.deleting
-        $StatusLabel.ForeColor = 'Blue'
-        $StatusLabel.Visible = $true
-
-        $success = IoBitDelete -Materials $Materials -Location $mcDest
-
-        if (-not $success) {
-            $StatusLabel.Text = $T.error_copy_failed
-            $StatusLabel.ForeColor = 'Red'
-            $StatusLabel.Visible = $true
-            return $false
+        if (-not (Test-Path $mcDest)) {
+            New-Item -ItemType Directory -Path $mcDest -Force -ErrorAction Stop | Out-Null
         }
 
-        Start-Sleep -Milliseconds 100
+        $isSideloaded = $Location -notlike "C:\Program Files\WindowsApps\*"
 
-        $StatusLabel.Text = $T.copying
-        $StatusLabel.ForeColor = 'Blue'
-        $StatusLabel.Visible = $true
-        
-        $success = IoBitCopy -Materials $Materials -Destination $mcDest -singlePass $doSinglePass
-
-        if (-not $success) {
-            $StatusLabel.Text = $T.error_copy_failed
-            $StatusLabel.ForeColor = 'Red'
-            $StatusLabel.Visible = $true
-            return $false
+        if ($isSideloaded) {
+            foreach ($material in $Materials) {
+                if (-not (Test-Path $material)) {
+                    throw "Source material not found: $material"
+                }
+                Copy-Item -Path $material -Destination $mcDest -Force -ErrorAction Stop
+            }
+            return $true
         }
 
-        return $true
-    }
+        if ($ioBit) {
+            $success = IoBitDelete -Materials $Materials -Location $mcDest
+            
+            if (-not $success) {
+                throw "Failed to delete existing files"
+            }
 
-    return $false
+            Start-Sleep -Milliseconds 100
+
+            $success = IoBitCopy -Materials $Materials -Destination $mcDest -singlePass $doSinglePass
+            if (-not $success) {
+                throw "Failed to copy new files"
+            }
+
+            return $true
+        }
+
+        return $false
+    }
+    catch {
+        return $false
+    }
 }
 
 function IoBitDelete() {
@@ -423,15 +526,49 @@ function Uninstall-Package() {
         [boolean]$restoreInitial
     )
 
-    if ($restoreInitial) {
-        foreach ($mc in $dataSrc) {
-            Copy-ShaderFiles -Location $mc.InstallLocation -Materials @("$BRTX_DIR\backup\$($mc.FriendlyName)\RTXStub.material.bin", "$BRTX_DIR\backup\$($mc.FriendlyName)\RTXPostFX.Tonemapping.material.bin")
+    try {
+        if ($restoreInitial) {
+            foreach ($mc in $dataSrc) {
+                $backupPath = "$BRTX_DIR\backup\$($mc.FriendlyName)"
+                if (Test-Path $backupPath) {
+                    Copy-ShaderFiles -Location $mc.InstallLocation -Materials @(
+                        "$backupPath\RTXStub.material.bin",
+                        "$backupPath\RTXPostFX.Tonemapping.material.bin"
+                    )
+                }
+            }
         }
+
+        if (Test-Path $BRTX_DIR) {
+            Remove-Item -Path $BRTX_DIR -Force -Recurse -ErrorAction Stop
+        }
+        
+        $form.Close()
+        Write-Host $T.uninstalled -ForegroundColor Green
+    }
+    catch {
+        Write-Error "Failed to uninstall package: $_"
+    }
+}
+
+function Expand-Pack() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Pack
+    )
+    $PackName = ($Pack -split "\\")[-1].Replace(".mcpack", "").Replace(".rtpack", "")
+    $PackDirName = Join-Path -Path $BRTX_DIR -ChildPath "packs\$PackName"
+    $PackDir = New-Item -ItemType Directory -Path $PackDirName -Force
+    $Zip = Join-Path -Path $PackDir -ChildPath "$PackName.zip"
+
+    if (Test-Path $Zip) {
+        Remove-Item -Path $Zip -Force
     }
 
-    Remove-Item -Path $BRTX_DIR -Force -Recurse
-    $form.Close()
-    Write-Host $T.uninstalled
+    Copy-Item -Path $Pack -Destination $Zip -Force
+    Expand-Archive -Path $Zip -DestinationPath $PackDir -Force
+
+    return $PackDir
 }
 
 function Expand-MinecraftPack() {
@@ -454,17 +591,15 @@ function Expand-MinecraftPack() {
     $StatusLabel.ForeColor = 'Blue'
     $StatusLabel.Visible = $true
 
-    $PackName = ($Pack -split "\\")[-1].Replace(".rtpack", "")
-    $PackDirName = Join-Path -Path $BRTX_DIR -ChildPath "packs\$PackName"
-    $PackDir = New-Item -ItemType Directory -Path $PackDirName -Force
-    $Zip = Join-Path -Path $PackDir -ChildPath "$PackName.zip"
-
-    if (Test-Path $Zip) {
-        Remove-Item -Path $Zip -Force
+    try {
+        $PackDir = Expand-Pack -Pack $Pack
     }
-
-    Copy-Item -Path $Pack -Destination $Zip -Force
-    Expand-Archive -Path $Zip -DestinationPath $PackDir -Force
+    catch {
+        $StatusLabel.Text = "$($T.error): $_"
+        $StatusLabel.ForeColor = 'Red'
+        $StatusLabel.Visible = $true
+        return $false
+    }
 
     # Loop through the files in the archive. Get the ones that end with ".material.bin"
     $Materials = Get-ChildItem -Path $PackDir -Recurse -Filter "*.material.bin" -Force
@@ -580,11 +715,14 @@ function DownloadPack() {
 }
 
 function ToggleInstallButton() {
+    $InstallButton.Enabled = $false
+
     # Enable install button when selection changes and both lists have a selection
-    $InstallButton.Enabled = ($ListBox.SelectedItems.Count -gt 0) -and ($PackSelectList.SelectedItem.Length -gt 1)
+    if (($ListBox.SelectedItems.Count -gt 0) -and ($PackSelectList.SelectedItem.Length -gt 1)) {
+        $InstallButton.Enabled = $true
+    }
 }
 
-# FIXME: This only backs up EXISTING materials and does not guarantee that the restoration will 
 if (-not (Test-Path "$BRTX_DIR\backup")) {
     Write-Host $T.create_initial_backup
     New-Item -ItemType Directory -Path "$BRTX_DIR\backup" -Force | Out-Null
@@ -593,7 +731,7 @@ if (-not (Test-Path "$BRTX_DIR\backup")) {
         New-Item -ItemType Directory -Path "$BRTX_DIR\backup\$($mc.FriendlyName)" -Force | Out-Null
         Backup-InitialShaderFiles -Location $mc.InstallLocation -BackupDir "$BRTX_DIR\backup\$($mc.FriendlyName)"
     }
-    Clear-Host
+    # Clear-Host
 }
 
 $lineHeight = 25
@@ -844,7 +982,20 @@ $backupMenuItem.Add_Click({
         }
     })
 
+$rtpackRegisterMenuItem = New-Object System.Windows.Forms.MenuItem;
+$rtpackRegisterMenuItem.Text = $T.register_rtpack;
+$rtpackRegisterMenuItem.Add_Click({
+        if (-not (Test-Path "$BRTX_DIR\installer.ps1")) {
+            Write-Host "Downloading BetterRTX installer"
+            $response = Invoke-WebRequest -Uri "https://raw.githubusercontent.com/BetterRTX/BetterRTX-Installer/main/v2/installer.ps1" -ContentType "application/json"
+            $response.Content | Out-File "$BRTX_DIR\installer.ps1"
+        }
+
+        Register-RtpackExtension -InstallerPath "$BRTX_DIR\installer.ps1"
+    })
+
 $fileMenu.MenuItems.Add($backupMenuItem) | Out-Null
+$fileMenu.MenuItems.Add($rtpackRegisterMenuItem) | Out-Null
 $mainMenu.MenuItems.Add($fileMenu) | Out-Null
 
 $helpMenu = New-Object System.Windows.Forms.MenuItem
@@ -867,6 +1018,16 @@ $uninstallMenu.Add_Click({ Uninstall-Package -restoreInitial $true })
 $fileMenu.MenuItems.Add($uninstallMenu) | Out-Null
 
 $form.Menu = $mainMenu
+
+# Handle command line arguments
+if ($args.Count -gt 0) {
+    Write-Host "Extracting preset: $args"
+    $success = Add-RunWithArguments -FilePath $args[0]
+
+    if ($success) {
+        exit;
+    }
+}
 
 $form.ShowDialog() | Out-Null
 

--- a/v2/installer.ps1
+++ b/v2/installer.ps1
@@ -83,6 +83,7 @@ foreach ($mc in (Get-AppxPackage -Name "Microsoft.Minecraft*")) {
     $dataSrc += [PSCustomObject]@{
         FriendlyName    = (Get-AppxPackageManifest -Package $mc).Package.Properties.DisplayName
         InstallLocation = $mc.InstallLocation
+        Preview         = ($mc.InstallLocation -like "*Beta*" -or $mc.FriendlyName -like "*Preview*")
     }
 }
 
@@ -754,7 +755,12 @@ $LaunchButton.Add_Click({
 
         $LaunchButton.Enabled = $false
 
-        Start-Process -FilePath "$($mc.InstallLocation)\Minecraft.Windows.exe" -PassThru
+        if ($mc.Preview -eq $true) {
+            Start-Process minecraft-preview:
+        }
+        else {
+            Start-Process minecraft:
+        }
 
         $LaunchButton.Visible = $false
     })
@@ -765,7 +771,7 @@ $InstallButton.Font = New-Object System.Drawing.Font("Arial", 12, [System.Drawin
 $InstallButton.Width = $containerWidth
 $InstallButton.Height = $lineHeight
 $InstallButton.Anchor = 'Bottom'
-$InstallButton.Enabled = $false
+$InstallButton.Enabled = $ListBox.Items.Count -eq 1
 
 $InstallButton.Add_Click({
         $StatusLabel.Visible = $false


### PR DESCRIPTION
### Changelog
- Added the ability to open and install `.rtpack` files directly in Windows. It is no longer required to drag-and-drop onto the installer (though that is still supported).
- Merged translation from @KiRura
- Added Copilot instructions to workspace for GitHub/VS Code

### Sanity Check
To test the latest version:

```powershell
iwr https://raw.githubusercontent.com/BetterRTX/BetterRTX-Installer/refs/heads/prerelease/v2/installer.ps1 | iex
```
(Super-slow to start. Possibly due to [recent changes](https://github.com/BetterRTX/BetterRTX-Installer/commit/bd7975295842e57f248ed5a0ded2b900d75167f3) in the locale check.)

- [ ]  Installer GUI still functions as before (API downloads / drag-and-drop install / drop-down install)
- [ ] **_Setup_ → _Register .rtpack extension_** menu item reports "Successfully registered .rtpack extension"
- [ ] Opening a .rtpack file launches a process to install the preset without the GUI. (GUI shows as a fallback.)